### PR TITLE
kpf: install kpfh helper, add caveats and tests

### DIFF
--- a/Formula/kpf.rb
+++ b/Formula/kpf.rb
@@ -9,6 +9,13 @@ class Kpf < Formula
 
   depends_on "python@3.14"
 
+  def caveats
+    <<~EOS
+      kpfh is now installed alongside kpf.
+      Use kpfh to quickly reconnect to previously used port-forwards.
+    EOS
+  end
+
   def install
     virtualenv_create(libexec, "python3.14")
 
@@ -16,8 +23,9 @@ class Kpf < Formula
     # This bypasses all the build system compatibility issues
     system libexec/"bin/python", "-m", "pip", "install", "--ignore-requires-python", "kpf==0.12.3"
 
-    # Create binary symlink
+    # Create binary symlinks
     bin.install_symlink libexec/"bin/kpf"
+    bin.install_symlink libexec/"bin/kpfh"
 
     # Install shell completions
     bash_completion.install "src/kpf/completions/kpf.bash" => "kpf"
@@ -27,6 +35,9 @@ class Kpf < Formula
   test do
     # Test that the kpf command exists and shows help
     assert_match "A better Kubectl Port-Forward", shell_output("#{bin}/kpf --help")
+
+    # Test that the kpfh command exists and shows help
+    assert_match "Usage:", shell_output("#{bin}/kpfh --help")
 
     # Test version output
     version_output = shell_output("#{bin}/kpf --version")


### PR DESCRIPTION
### Motivation
- Make the newly included helper `kpfh` available to users and document its presence via the formula `caveats` so users know to use it for quick reconnects.

### Description
- Add a `caveats` method that informs users that `kpfh` is installed alongside `kpf` and its purpose.
- Install an additional binary symlink using `bin.install_symlink` for the `kpfh` entry point alongside the existing `kpf` symlink.
- Add a test assertion that runs `kpfh --help` to validate the helper is present and responds to help output.

### Testing
- Ran the formula's `test` block via `brew test kpf` and the assertions for `kpf --help`, `kpfh --help`, and `kpf --version` all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d3e4a148833097a52a80281bbe55)