### PR TITLE
Preserve kpfh formula behavior in updater

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -102,28 +102,26 @@ jobs:
       - name: Check if update needed
         id: check-update
         run: |
-          # Extract current version from formula
-          if [[ -f Formula/kpf.rb ]]; then
-            CURRENT_VERSION=$(grep -o 'kpf-[0-9]*\.[0-9]*\.[0-9]*' Formula/kpf.rb | sed 's/kpf-//' || echo "")
-            if [[ -z "$CURRENT_VERSION" ]]; then
-              # Try alternative pattern for direct PyPI installation
-              CURRENT_VERSION=$(grep -o 'kpf==[0-9]*\.[0-9]*\.[0-9]*' Formula/kpf.rb | sed 's/kpf==//' || echo "0.0.0")
-            fi
-          else
-            CURRENT_VERSION="0.0.0"
-          fi
-          
+          CURRENT_VERSION=$(python3 scripts/formula-updater.py --current-version Formula/kpf.rb)
           NEW_VERSION="${{ steps.version-info.outputs.version }}"
           
           echo "Current version: $CURRENT_VERSION"
           echo "New version: $NEW_VERSION"
-          
+
+          set +e
+          python3 scripts/formula-updater.py --validate-formula Formula/kpf.rb --version "$CURRENT_VERSION"
+          FORMULA_VALID=$?
+          set -e
+
           if [[ "$CURRENT_VERSION" != "$NEW_VERSION" ]]; then
             echo "update-needed=true" >> $GITHUB_OUTPUT
             echo "Update needed from $CURRENT_VERSION to $NEW_VERSION"
+          elif [[ "$FORMULA_VALID" -ne 0 ]]; then
+            echo "update-needed=true" >> $GITHUB_OUTPUT
+            echo "Formula is at $NEW_VERSION but is missing required tap behavior; regenerating"
           else
             echo "update-needed=false" >> $GITHUB_OUTPUT
-            echo "No update needed, already at version $NEW_VERSION"
+            echo "No update needed, already at version $NEW_VERSION with required tap behavior"
           fi
 
       - name: Generate updated formula
@@ -136,6 +134,12 @@ jobs:
           
           echo "Generated formula:"
           cat Formula/kpf.rb
+
+      - name: Validate generated formula
+        if: steps.check-update.outputs.update-needed == 'true'
+        run: |
+          VERSION="${{ steps.version-info.outputs.version }}"
+          python3 scripts/formula-updater.py --validate-formula Formula/kpf.rb --version "$VERSION"
 
       - name: Test formula syntax
         if: steps.check-update.outputs.update-needed == 'true'
@@ -171,7 +175,7 @@ jobs:
         if: steps.check-update.outputs.update-needed == 'true'
         run: |
           echo "Changes to be committed:"
-          git diff --no-index /dev/null Formula/kpf.rb || true
+          git diff -- Formula/kpf.rb scripts/formula-updater.py
           git status
 
       - name: Commit changes
@@ -188,6 +192,7 @@ jobs:
 
           - Updated to PyPI version $VERSION  
           - Updated source URL and SHA256 checksum
+          - Preserved kpfh symlink, tests, and install caveats
           - Generated via automated formula-updater.py script
           - Source: $URL
 

--- a/Formula/kpf.rb
+++ b/Formula/kpf.rb
@@ -9,6 +9,13 @@ class Kpf < Formula
 
   depends_on "python@3.14"
 
+  def caveats
+    <<~EOS
+      kpfh is installed alongside kpf.
+      Use kpfh to quickly reconnect to previously used port-forwards.
+    EOS
+  end
+
   def install
     virtualenv_create(libexec, "python3.14")
 
@@ -16,8 +23,9 @@ class Kpf < Formula
     # This bypasses all the build system compatibility issues
     system libexec/"bin/python", "-m", "pip", "install", "--ignore-requires-python", "kpf==0.12.4"
 
-    # Create binary symlink
+    # Create binary symlinks
     bin.install_symlink libexec/"bin/kpf"
+    bin.install_symlink libexec/"bin/kpfh"
 
     # Install shell completions
     bash_completion.install "src/kpf/completions/kpf.bash" => "kpf"
@@ -27,6 +35,9 @@ class Kpf < Formula
   test do
     # Test that the kpf command exists and shows help
     assert_match "A better Kubectl Port-Forward", shell_output("#{bin}/kpf --help")
+
+    # Test that the kpfh command exists and shows help
+    assert_match "Usage:", shell_output("#{bin}/kpfh --help")
 
     # Test version output
     version_output = shell_output("#{bin}/kpf --version")

--- a/scripts/formula-updater.py
+++ b/scripts/formula-updater.py
@@ -6,44 +6,72 @@ This script handles fetching PyPI package information and updating/generating
 Homebrew formulas for the kpf package.
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import os
+import re
 import sys
+from pathlib import Path
 from typing import Dict
 
-try:
-    import requests
-except ImportError:
-    print("Error: requests module not found. Please install with: pip install requests")
-    sys.exit(1)
+FORMULA_CLASS_NAME = "Kpf"
+FORMULA_NAME = "kpf"
+PYTHON_FORMULA = "python@3.14"
+PYTHON_EXECUTABLE = "python3.14"
+HOMEPAGE_FALLBACK = "https://github.com/jessegoodier/kpf"
+DESCRIPTION = "Kubernetes utility to improve kubectl port-forward reliability and usability"
+EXPECTED_COMMANDS = ("kpf", "kpfh")
+CAVEATS = """      kpfh is installed alongside kpf.
+      Use kpfh to quickly reconnect to previously used port-forwards."""
+CURRENT_VERSION_PATTERNS = (
+    re.compile(r"kpf==(?P<version>[0-9]+\.[0-9]+\.[0-9]+[^\"'\s]*)"),
+    re.compile(r"kpf-(?P<version>[0-9]+\.[0-9]+\.[0-9]+[^\"'\s]*)\.tar\.gz"),
+)
+
+
+def import_requests():
+    """Import requests only for network-backed operations."""
+    try:
+        import requests
+    except ImportError:
+        print(
+            "Error: requests module not found. Please install with: pip install requests",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return requests
 
 
 class FormulaUpdater:
-    def __init__(self, package_name: str = "kpf"):
+    def __init__(self, package_name: str = FORMULA_NAME):
         self.package_name = package_name
         self.pypi_base_url = "https://pypi.org/pypi"
 
     def fetch_latest_version(self) -> str:
         """Fetch the latest version from PyPI."""
         url = f"{self.pypi_base_url}/{self.package_name}/json"
+        requests = import_requests()
         try:
             response = requests.get(url, timeout=30)
             response.raise_for_status()
             data = response.json()
             version = data["info"]["version"]
-            print(f"Latest version from PyPI: {version}")
+            print(f"Latest version from PyPI: {version}", file=sys.stderr)
             return version
         except requests.RequestException as e:
-            print(f"Error fetching latest version: {e}")
+            print(f"Error fetching latest version: {e}", file=sys.stderr)
             sys.exit(1)
         except KeyError as e:
-            print(f"Error parsing PyPI response: {e}")
+            print(f"Error parsing PyPI response: {e}", file=sys.stderr)
             sys.exit(1)
 
     def fetch_version_info(self, version: str) -> Dict[str, str]:
         """Fetch version-specific information from PyPI."""
         url = f"{self.pypi_base_url}/{self.package_name}/{version}/json"
+        requests = import_requests()
         try:
             response = requests.get(url, timeout=30)
             response.raise_for_status()
@@ -60,13 +88,16 @@ class FormulaUpdater:
                     break
 
             if not sdist_url:
-                print(f"No source distribution found for version {version}")
+                print(
+                    f"No source distribution found for version {version}",
+                    file=sys.stderr,
+                )
                 sys.exit(1)
 
             homepage = (
                 data["info"].get("home_page")
                 or data["info"].get("project_urls", {}).get("Homepage")
-                or "https://github.com/jessegoodier/kpf"
+                or HOMEPAGE_FALLBACK
             )
 
             return {
@@ -74,38 +105,54 @@ class FormulaUpdater:
                 "url": sdist_url,
                 "sha256": sdist_sha256,
                 "homepage": homepage,
-                "description": "Kubernetes utility to improve kubectl port-forward reliability and usability",
+                "description": DESCRIPTION,
             }
 
         except requests.RequestException as e:
-            print(f"Error fetching version {version}: {e}")
+            print(f"Error fetching version {version}: {e}", file=sys.stderr)
             sys.exit(1)
         except KeyError as e:
-            print(f"Error parsing PyPI response: {e}")
+            print(f"Error parsing PyPI response: {e}", file=sys.stderr)
             sys.exit(1)
 
     def generate_formula_content(self, version_info: Dict[str, str]) -> str:
-        """Generate the complete Homebrew formula content."""
-        formula_template = """class Kpf < Formula
+        """Generate the complete Homebrew formula content.
+
+        Keep tap-local behavior, such as caveats and additional command symlinks,
+        in this template so automated version bumps cannot overwrite them.
+        """
+        version = version_info["version"]
+        command_symlinks = "\n".join(
+            f'    bin.install_symlink libexec/"bin/{command}"'
+            for command in EXPECTED_COMMANDS
+        )
+
+        return f'''class {FORMULA_CLASS_NAME} < Formula
   include Language::Python::Virtualenv
 
-  desc "Kubernetes utility to improve kubectl port-forward reliability and usability"
-  homepage "{homepage}"
-  url "{url}"
-  sha256 "{sha256}"
+  desc "{version_info["description"]}"
+  homepage "{version_info["homepage"]}"
+  url "{version_info["url"]}"
+  sha256 "{version_info["sha256"]}"
   license "MIT"
 
-  depends_on "python@3.14"
+  depends_on "{PYTHON_FORMULA}"
+
+  def caveats
+    <<~EOS
+{CAVEATS}
+    EOS
+  end
 
   def install
-    virtualenv_create(libexec, "python3.14")
+    virtualenv_create(libexec, "{PYTHON_EXECUTABLE}")
 
     # Install kpf and its dependencies directly from PyPI using wheels
     # This bypasses all the build system compatibility issues
-    system libexec/"bin/python", "-m", "pip", "install", "--ignore-requires-python", "kpf=={version}"
+    system libexec/"bin/python", "-m", "pip", "install", "--ignore-requires-python", "{self.package_name}=={version}"
 
-    # Create binary symlink
-    bin.install_symlink libexec/"bin/kpf"
+    # Create binary symlinks
+{command_symlinks}
 
     # Install shell completions
     bash_completion.install "src/kpf/completions/kpf.bash" => "kpf"
@@ -116,13 +163,15 @@ class FormulaUpdater:
     # Test that the kpf command exists and shows help
     assert_match "A better Kubectl Port-Forward", shell_output("#{{bin}}/kpf --help")
 
+    # Test that the kpfh command exists and shows help
+    assert_match "Usage:", shell_output("#{{bin}}/kpfh --help")
+
     # Test version output
     version_output = shell_output("#{{bin}}/kpf --version")
     assert_match "kpf {version}", version_output
   end
-end"""
-
-        return formula_template.format(**version_info)
+end
+'''
 
     def output_results(self, version_info: Dict[str, str], output_format: str) -> None:
         """Output results in the specified format."""
@@ -150,19 +199,65 @@ end"""
     def write_formula(self, version_info: Dict[str, str], output_file: str) -> None:
         """Write the formula to a file."""
         formula_content = self.generate_formula_content(version_info)
+        self.validate_formula_content(formula_content, version_info["version"])
 
         try:
-            # Create directory if needed (only if there's a directory component)
-            dir_path = os.path.dirname(output_file)
-            if dir_path:
-                os.makedirs(dir_path, exist_ok=True)
-
-            with open(output_file, "w") as f:
-                f.write(formula_content)
+            output_path = Path(output_file)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(formula_content)
             print(f"Formula written to {output_file}")
         except IOError as e:
-            print(f"Error writing formula file: {e}")
+            print(f"Error writing formula file: {e}", file=sys.stderr)
             sys.exit(1)
+
+    @staticmethod
+    def read_current_version(formula_file: str) -> str:
+        """Read the currently pinned version from a formula file."""
+        formula_path = Path(formula_file)
+        if not formula_path.exists():
+            return "0.0.0"
+
+        formula_content = formula_path.read_text()
+        for pattern in CURRENT_VERSION_PATTERNS:
+            match = pattern.search(formula_content)
+            if match:
+                return match.group("version")
+
+        return "0.0.0"
+
+    @staticmethod
+    def validate_formula_content(
+        formula_content: str, expected_version: str | None = None
+    ) -> None:
+        """Validate generated formula content includes required tap behavior."""
+        required_snippets = [
+            "def caveats",
+            "kpfh is installed alongside kpf.",
+            'bin.install_symlink libexec/"bin/kpf"',
+            'bin.install_symlink libexec/"bin/kpfh"',
+            'shell_output("#{bin}/kpfh --help")',
+        ]
+
+        if expected_version:
+            required_snippets.append(f'"{FORMULA_NAME}=={expected_version}"')
+            required_snippets.append(f'assert_match "kpf {expected_version}"')
+
+        missing_snippets = [
+            snippet for snippet in required_snippets if snippet not in formula_content
+        ]
+        if missing_snippets:
+            print("Formula validation failed. Missing required content:", file=sys.stderr)
+            for snippet in missing_snippets:
+                print(f"  - {snippet}", file=sys.stderr)
+            sys.exit(1)
+
+    def validate_formula_file(
+        self, formula_file: str, expected_version: str | None = None
+    ) -> None:
+        """Validate an existing formula file includes required tap behavior."""
+        formula_content = Path(formula_file).read_text()
+        self.validate_formula_content(formula_content, expected_version)
+        print(f"Formula validation passed: {formula_file}")
 
 
 def main():
@@ -180,12 +275,18 @@ Examples:
   # Generate formula file
   %(prog)s --version 0.1.10 --output-formula Formula/kpf.rb
 
+  # Read the current formula version
+  %(prog)s --current-version Formula/kpf.rb
+
+  # Validate the generated tap-specific formula behavior
+  %(prog)s --validate-formula Formula/kpf.rb --version 0.1.10
+
   # Output for GitHub Actions
   %(prog)s --fetch-version-from-pypi --output-format env
         """,
     )
 
-    version_group = parser.add_mutually_exclusive_group(required=True)
+    version_group = parser.add_mutually_exclusive_group(required=False)
     version_group.add_argument("--version", help="Specific version to use")
     version_group.add_argument(
         "--fetch-version-from-pypi",
@@ -201,14 +302,36 @@ Examples:
     )
 
     parser.add_argument("--output-formula", help="Write formula to specified file")
+    parser.add_argument(
+        "--current-version", help="Read current version from formula file"
+    )
+    parser.add_argument(
+        "--validate-formula", help="Validate generated formula behavior"
+    )
 
     parser.add_argument(
-        "--package-name", default="kpf", help="Package name on PyPI (default: kpf)"
+        "--package-name",
+        default=FORMULA_NAME,
+        help=f"Package name on PyPI (default: {FORMULA_NAME})",
     )
 
     args = parser.parse_args()
 
+    if args.current_version:
+        print(FormulaUpdater.read_current_version(args.current_version))
+        return
+
     updater = FormulaUpdater(args.package_name)
+
+    if args.validate_formula:
+        updater.validate_formula_file(args.validate_formula, args.version)
+        return
+
+    if not args.version and not args.fetch_version_from_pypi:
+        parser.error(
+            "one of --version, --fetch-version-from-pypi, --current-version, "
+            "or --validate-formula is required"
+        )
 
     # Get version
     if args.fetch_version_from_pypi:


### PR DESCRIPTION
### Motivation

- Prevent the automated workflow from overwriting tap-specific changes that added `kpfh` support and install caveats. 
- Make the updater and workflow more robust and easier to maintain by centralizing tap-local behavior in the generator.

### Description

- Restore `kpfh` support in the formula by adding the install `caveats`, installing a `kpfh` binary symlink alongside `kpf`, and adding a `kpfh` help check in `Formula/kpf.rb`.
- Rework `scripts/formula-updater.py` to centralize template constants and expected commands, defer importing `requests` to network operations, generate a formula template that includes the caveats and `kpfh` symlink, and validate generated content.
- Add CLI helpers to the updater: `--current-version` to read the pinned version from a formula and `--validate-formula` to ensure required tap behavior (caveats, `kpfh` symlink, tests) is present.
- Update `.github/workflows/update-formula.yml` to use the updater for current-version detection, run formula validation, regenerate when required tap behavior is missing, validate generated output, diff both `Formula/kpf.rb` and `scripts/formula-updater.py`, and reflect preserved `kpfh` behavior in the workflow messaging.

### Testing

- `python3 -m py_compile scripts/formula-updater.py` ran successfully.
- `python3 scripts/formula-updater.py --current-version Formula/kpf.rb` returned the current pinned version successfully.
- `python3 scripts/formula-updater.py --validate-formula Formula/kpf.rb --version 0.12.4` validated the existing formula and returned success.
- `ruby -c Formula/kpf.rb` confirmed the formula ruby syntax is valid and workflow YAML loads with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/update-formula.yml")'`.
- `git diff --check` reported no issues after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01db8080dc8330a6b08cce7a3d2e37)